### PR TITLE
fix ansheng android ua parse issue

### DIFF
--- a/uaparser/yaml.go
+++ b/uaparser/yaml.go
@@ -3508,7 +3508,7 @@ device_parsers:
   - regex: 'Android \d+?(?:\.\d+|)(?:\.\d+|); ([^;]{1,100}?)(?: Build|\) AppleWebKit).{1,200}? Safari'
     brand_replacement: 'Generic_Android_Tablet'
     model_replacement: '$1'
-  - regex: 'Android \d+?(?:\.\d+|)(?:\.\d+|); ([^;]{1,100}?)(?: Build|\))'
+  - regex: 'Android \d+?(?:\.\d+|)(?:\.\d+|); ([^;]{1,100}?)(?: Build|;)'
     brand_replacement: 'Generic_Android'
     model_replacement: '$1'
   - regex: '(GoogleTV)'


### PR DESCRIPTION
ansheng UA:
"SJYH/3.10.5 (Linux; U; Android Android 12; zh-cn)"

正常UA
Mozilla/5.0 (Linux; Android 9; SM-G973U Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36

当前 zh-cn 会被提取为device。 更改之后， 包含Build 或者倒数第一个；之前的部分才是device

例如

Mozilla/5.0 (Linux; Android 12; SM-S906N Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.119 Mobile Safari/537.36